### PR TITLE
Update epel-release RPM version

### DIFF
--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -3,7 +3,7 @@ os_version_major: "{{ ansible_distribution_major_version }}"
 # EPEL repository released packaged per OS version
 epel_releases:
   '6': 'epel-release-6-8.noarch.rpm'
-  '7': 'e/epel-release-7-9.noarch.rpm'
+  '7': 'e/epel-release-7-10.noarch.rpm'
 
 # Mesosphere released packaged per OS version
 mesosphere_releases:


### PR DESCRIPTION
The available release for epel-release is now at 7-10.

https://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-10.noarch.rpm

### Short description:

I found the following issue(s) or bug(s):
  - 

_And/OR_

I found that the following _enhancement_ is worthwhile:
  - 


### Bookkeeping
I did the following bookkeeping:
 - [ ] If a major change, bumped the playbook version in `vars/`
 - [ ] Added as much documentation as I could (we're not looking a book, just enough to help others)
 - [ ] Confirmed that the PR works by running the vagrant tests (if any) and/or added to the tests (see `ci/` or legacy `tests/`)
 - [ ] Followed up with any automated test results as a result of the pull request
